### PR TITLE
Add option to specify order of taps

### DIFF
--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -54,29 +54,35 @@ describe("sync hook", () => {
     syncHook.tap("tap1", (input) => {
       return [...input, 'tap1']
     });
-    syncHook.tap({name: "tap2", before: "tap1"}, (input) => {
+    syncHook.tap({name: "tap2", before: "tap1"} , (input) => {
       return [...input, 'tap2']
+    });
+    syncHook.tap({name: "tap3", before: ["tap1", "tap2"]}, (input) => {
+      return [...input, 'tap3']
     });
 
     const result = syncHook.call([]);
 
-    expect(result).toStrictEqual(["tap2", "tap1"]);
+    expect(result).toStrictEqual(["tap3", "tap2", "tap1"]);
   });
 
   it("can specify tap order for future taps", () => {
     const syncHook = new SyncWaterfallHook<[Array<string>]>();
 
-    syncHook.tap({name: "tap2", before: "tap1"}, (input) => {
+    syncHook.tap({name: "tap3", before: ["tap1", "tap2"]}, (input) => {
+      return [...input, 'tap3']
+    });
+    syncHook.tap({name: "tap2", before: "tap1"} , (input) => {
       return [...input, 'tap2']
     });
-    
     syncHook.tap("tap1", (input) => {
       return [...input, 'tap1']
     });
 
+
     const result = syncHook.call([]);
 
-    expect(result).toStrictEqual(["tap2", "tap1"]);
+    expect(result).toStrictEqual(["tap3", "tap2", "tap1"]);
   });
 
   it("works with no taps", () => {

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -5,7 +5,6 @@ import {
   AsyncSeriesHook,
   AsyncSeriesLoopHook,
   AsyncSeriesWaterfallHook,
-  Interceptor,
   SyncBailHook,
   SyncHook,
   SyncLoopHook,
@@ -47,6 +46,37 @@ describe("sync hook", () => {
 
     expect(tap1).toBeCalledWith("hello", "world");
     expect(tap2).toBeCalledWith("hello", "world");
+  });
+
+  it("can specify tap order", () => {
+    const syncHook = new SyncWaterfallHook<[Array<string>]>();
+
+    syncHook.tap("tap1", (input) => {
+      return [...input, 'tap1']
+    });
+    syncHook.tap({name: "tap2", before: "tap1"}, (input) => {
+      return [...input, 'tap2']
+    });
+
+    const result = syncHook.call([]);
+
+    expect(result).toStrictEqual(["tap2", "tap1"]);
+  });
+
+  it("can specify tap order for future taps", () => {
+    const syncHook = new SyncWaterfallHook<[Array<string>]>();
+
+    syncHook.tap({name: "tap2", before: "tap1"}, (input) => {
+      return [...input, 'tap2']
+    });
+    
+    syncHook.tap("tap1", (input) => {
+      return [...input, 'tap1']
+    });
+
+    const result = syncHook.call([]);
+
+    expect(result).toStrictEqual(["tap2", "tap1"]);
   });
 
   it("works with no taps", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Checks if `value` is equal to `check` if `check` is a string or in `check` if check is an Array
+ * @param value the value being searched for
+ * @param check the values to check against
+ * @returns `boolean`
+ */
+export function equalToOrIn(value: string, check: string | Array<string>){
+  if(Array.isArray(check)){
+    return check.includes(value)
+  } else {
+    return check === value
+  }
+}


### PR DESCRIPTION
Adds a parameter `before` to specify which, if any, taps the new tap should be called before. This API exists in the original webpack implementation so this should bring it a bit more inline with it's API. 