### PR TITLE
Fix unexpected `before` tap option behavior

### DIFF
--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -60,15 +60,21 @@ describe("sync hook", () => {
     syncHook.tap({name: "tap3", before: ["tap1", "tap2"]}, (input) => {
       return [...input, 'tap3']
     });
+    syncHook.tap({name: "tap4", before: ["tap3"]}, (input) => {
+      return [...input, 'tap4']
+    });
 
     const result = syncHook.call([]);
 
-    expect(result).toStrictEqual(["tap3", "tap2", "tap1"]);
+    expect(result).toStrictEqual(["tap4","tap3", "tap2", "tap1"]);
   });
 
   it("can specify tap order for future taps", () => {
     const syncHook = new SyncWaterfallHook<[Array<string>]>();
 
+    syncHook.tap({name: "tap4", before: "tap2"}, (input) => {
+      return [...input, 'tap4']
+    });
     syncHook.tap({name: "tap3", before: ["tap1", "tap2"]}, (input) => {
       return [...input, 'tap3']
     });
@@ -82,7 +88,7 @@ describe("sync hook", () => {
 
     const result = syncHook.call([]);
 
-    expect(result).toStrictEqual(["tap3", "tap2", "tap1"]);
+    expect(result).toStrictEqual(["tap4","tap3", "tap2", "tap1"]);
   });
 
   it("works with no taps", () => {

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -88,7 +88,28 @@ describe("sync hook", () => {
 
     const result = syncHook.call([]);
 
-    expect(result).toStrictEqual(["tap4","tap3", "tap2", "tap1"]);
+    expect(result).toStrictEqual(["tap3", "tap4", "tap2", "tap1"]);
+  });
+
+  it("mixed tap order", () => {
+    const syncHook = new SyncWaterfallHook<[Array<string>]>();
+
+
+    syncHook.tap({name: "tap1", before: "tap0"}, (input) => {
+      return [...input, 'tap1']
+    });
+    syncHook.tap("tap2" , (input) => {
+      return [...input, 'tap2']
+    });
+    syncHook.tap({name: "tap0", before: ["tap3"]}, (input) => {
+      return [...input, 'tap0']
+    });
+    syncHook.tap({name: "tap3", before: ["tap2"]}, (input) => {
+      return [...input, 'tap3']
+    });   
+    const result = syncHook.call([]);
+
+    expect(result).toStrictEqual(["tap1","tap0","tap3", "tap2"]);
   });
 
   it("works with no taps", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,18 +219,18 @@ abstract class Hook<
       callback,
     };
 
-    this.taps.push(tap);
-    this.taps.sort((A, B) => {
-      if(A.before && equalToOrIn(B.name, A.before)){
-        return -1
-      } 
-
-      if (B.before && equalToOrIn(A.name, B.before)){
-        return 1
+    if(tap.before){
+      let i
+      for(i = 0; i < this.taps.length; i++){
+        const t = this.taps[i]
+        if(equalToOrIn(t.name, tap.before)){
+          break
+        }
       }
-
-      return 0
-    })
+      this.taps.splice(i, 0, tap)
+    } else {
+      this.taps.push(tap)
+    }
 
     this.interceptions.tap(tap);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,14 +220,18 @@ abstract class Hook<
     };
 
     if(tap.before){
-      let i
-      for(i = 0; i < this.taps.length; i++){
-        const t = this.taps[i]
-        if(equalToOrIn(t.name, tap.before)){
+      let insertionIndex = this.taps.length
+      const beforeSet = new Set(Array.isArray(tap.before) ? tap.before : [tap.before])
+      for(insertionIndex; insertionIndex > 0 && beforeSet.size > 0; insertionIndex--){
+        const t = this.taps[insertionIndex-1]
+        if(beforeSet.has(t.name)){
+          beforeSet.delete(t.name)
+        }
+        if(t.before && equalToOrIn(tap.name, t.before)){
           break
         }
       }
-      this.taps.splice(i, 0, tap)
+      this.taps.splice(insertionIndex, 0, tap)
     } else {
       this.taps.push(tap)
     }


### PR DESCRIPTION
Currently If a tap supplies a `before` option but the last tap on the hook isn't one that it needs to go before, the tap will remain at the end of the queue. This is because JavaScript sorting requires the comparison function to be logically transitive. However in this case, since there is no transitivity in the `before` logic this results in unexpected behavior. This new approach does the following:

1) **If no before is supplied, it is put a the end of the queue.** This ensures that any taps already present that may or may not have a before, will always be before something that may be tapped in the future. 
2) **If a before is supplied, the list of taps are searched for the first tap it is supposed to be before or the first tap that needs to go before it and it is inserted into the list at that point**. This covers cases for taps that have `before` arguments for future taps that also have `before` arguments where the tap needs to be somewhere in the middle. 